### PR TITLE
Fix Symlink resolution

### DIFF
--- a/package/yast2-live-installer.changes
+++ b/package/yast2-live-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan 26 18:52:20 UTC 2016 - martin.koegler@chello.at
+
+- fix replacing symlinks to /livecd/* by their target file/directory
+
+-------------------------------------------------------------------
 Thu Dec  4 09:50:25 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/src/clients/inst_live_doit.rb
+++ b/src/clients/inst_live_doit.rb
@@ -30,6 +30,7 @@ module Yast
       Yast.import "Pkg"
       textdomain "live-installer"
 
+      Yast.import "FileUtils"
       Yast.import "Installation"
       Yast.import "Progress"
       Yast.import "Wizard"
@@ -92,13 +93,9 @@ module Yast
     # Find symlinks which need to be resolved and copied
     # @return a list of such symlinks
     def LinksToCopyList
-      cmd = Builtins.sformat(
-        "\n" +
-          "\tfor LINK in `find %1 -xdev -type l` ; do\n" +
-          "\t    stat -c \"%%N\" $LINK |grep livecd >/dev/null 2>/dev/null && echo $LINK;\n" +
-          "\tdone; exit 0",
-        Installation.destdir
-      )
+      cmd = "\tfor LINK in `find / -xdev -type l` ; do\n" +
+          "\t    stat -c \"%N\" $LINK |grep livecd >/dev/null 2>/dev/null && echo $LINK;\n" +
+          "\tdone; exit 0"
       Builtins.y2milestone("Executing %1", cmd)
       out = Convert.to_map(SCR.Execute(path(".target.bash_output"), cmd))
       Builtins.y2milestone("Result: %1", out)
@@ -168,12 +165,19 @@ module Yast
         # 	    components[size(components) - 1] = "";
         # 	link = mergestring (components, "/");
         progress_done = Ops.add(progress_start, progress_step)
-        ret = ImageInstallation.FileSystemCopy(
-          Ops.add("/", target),
-          Builtins.sformat("%1/%2", Installation.destdir, link),
-          progress_start,
-          progress_done
-        ) && ret
+        if FileUtils.IsDirectory(target)
+          ret = ImageInstallation.FileSystemCopy(
+            Ops.add("/", target),
+            Builtins.sformat("%1/%2", Installation.destdir, link),
+            progress_start,
+            progress_done
+          ) && ret
+        else
+          SCR.Execute(
+            path(".target.bash"),
+            Builtins.sformat("/bin/cp -a %1 %2/%3", target, Installation.destdir, link)
+          )
+        end
         progress_start = progress_done
         #	Progress::Step (progress_start);
         SlideShow.StageProgress(progress_done, nil)


### PR DESCRIPTION
The destination is still empty, while searching for symlinks.
Use cp for copying non-directories.