### PR TITLE
add correct_live_* scripts needed for live installer to function properly

### DIFF
--- a/package/correct_live_for_reboot
+++ b/package/correct_live_for_reboot
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+# this script is called from the live installer once it finished copying the live
+# image. So we only do the minimal changes necessary to reboot into the system
+
+is_usb=0
+if test "$1" = usb; then
+  is_usb=1
+fi
+
+chkconfig sshd on
+chkconfig cron on
+if test -e /etc/init.d/boot.compcache; then
+   chkconfig boot.compcache off
+fi
+rm /usr/lib/systemd/system/sysinit.target.wants/langset.service
+rm /usr/lib/systemd/system/langset.service /usr/lib/systemd/system/sysinit.target.wants/langset.service
+
+
+: > /var/run/utmp
+
+# remove live-cd user
+userdel linux
+# a lot of stuff!
+rm -rf /home/linux/.local/share/akonadi
+mv /home/linux /home/linux~
+
+#undo journald.conf changes, bug 950999
+sed -i -e s@Storage=volatile@@ /etc/systemd/journald.conf
+
+#workaround for missing initrd
+grub2-mkconfig -o /boot/grub2/grub.cfg
+mkinitrd
+

--- a/package/correct_live_install
+++ b/package/correct_live_install
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+# this script is called from the live installer once it is done (including 2nd stage)
+# So the goal of this script is to fix whatever configs were changed for the live system
+
+#======================================
+# /etc/sudoers hack to fix #297695 
+# (Installation Live CD: no need to ask for password of root)
+#--------------------------------------
+sed -i -e "s/ALL ALL=(ALL) NOPASSWD: ALL/ALL ALL=(ALL) ALL/" /etc/sudoers
+chmod 0440 /etc/sudoers
+
+# bug 544314, we need to use pam-config to correctly reset the gnome-keyring-pam config (see bug 723339)
+pam_config_keyring=`rpm -q --scripts gnome-keyring-pam | grep -v " *#" | grep "pam-config *-a" | head -n 1`
+test -n "$pam_config_keyring" && eval "$pam_config_keyring"
+
+# reset pam config
+pam-config -d --nullok
+
+# remove unneeded /license.tar.gz
+rm /license.tar.gz
+
+# remove langset stuff
+rm /etc/langset.sh
+rm -rf /etc/langset/
+
+# bug 391798
+sed -i -e 's,DISPLAYMANAGER_AUTOLOGIN="linux",DISPLAYMANAGER_AUTOLOGIN="",'  /etc/sysconfig/displaymanager
+
+rm -f /var/lib/zypp/AnonymousUniqueId
+rmdir /livecd || true
+rmdir /read-only || true
+rmdir /read-write || true
+

--- a/package/yast2-live-installer.changes
+++ b/package/yast2-live-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jul 28 13:03:03 UTC 2016 - cyberorg@opensuse.org
+
+- correct_live_* scripts are removed from kiwi config
+  these scripts are required to get yast2-live-installer function,
+  the scripts belong in this package
+- Added Requires for yast modules needed by live-installer
+
+-------------------------------------------------------------------
 Tue Jun  7 08:21:02 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -22,7 +22,8 @@ Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
-
+Source1:        correct_live_for_reboot
+Source2:        correct_live_install
 Group:	        System/YaST
 License:        GPL-2.0+
 
@@ -32,7 +33,8 @@ Requires:	yast2-network >= 2.16.6
 Requires:	yast2-bootloader >= 2.18.7
 #unified progress
 Requires:	yast2-installation >= 2.18.17
-
+Requires:       yast2-qt-branding-openSUSE
+Requires:       yast2-users
 Requires:	yast2-bootloader yast2-country yast2-storage
 BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-testsuite
 BuildRequires:  yast2-devtools >= 3.1.10
@@ -55,11 +57,16 @@ hard disk of the computer.
 
 %install
 %yast_install
-
+%__install -d -m 755 %{buildroot}/%_bindir/
+cp %{SOURCE1} %{buildroot}/%_bindir/
+cp %{SOURCE2} %{buildroot}/%_bindir/
+chmod 755 %{buildroot}/%_bindir/*
 
 %files
 %defattr(-,root,root)
 %{yast_clientdir}/*.rb
 %{yast_moduledir}/LiveInstaller.*
 %{yast_desktopdir}/live-installer.desktop
+%_bindir/correct_live_for_reboot
+%_bindir/correct_live_install
 %doc %{yast_docdir}

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-live-installer
-Version:        3.1.8
+Version:        3.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- correct_live_* scripts are removed from kiwi config
  these scripts are required to get yast2-live-installer function,
  the scripts belong in this package
- Added Requires for yast modules needed by live-installer
