### PR TITLE
- Use /etc/products.d/openSUSE.prod as /etc/products.d/baseproduct

### DIFF
--- a/package/correct_live_for_reboot
+++ b/package/correct_live_for_reboot
@@ -16,14 +16,7 @@ fi
 rm /usr/lib/systemd/system/sysinit.target.wants/langset.service
 rm /usr/lib/systemd/system/langset.service /usr/lib/systemd/system/sysinit.target.wants/langset.service
 
-
 : > /var/run/utmp
-
-# remove live-cd user
-userdel linux
-# a lot of stuff!
-rm -rf /home/linux/.local/share/akonadi
-mv /home/linux /home/linux~
 
 #undo journald.conf changes, bug 950999
 sed -i -e s@Storage=volatile@@ /etc/systemd/journald.conf

--- a/package/correct_live_install
+++ b/package/correct_live_install
@@ -7,8 +7,10 @@
 # /etc/sudoers hack to fix #297695 
 # (Installation Live CD: no need to ask for password of root)
 #--------------------------------------
-sed -i -e "s/ALL ALL=(ALL) NOPASSWD: ALL/ALL ALL=(ALL) ALL/" /etc/sudoers
-chmod 0440 /etc/sudoers
+if [ -f /etc/sudoers ] ; then
+  sed -i -e "s/ALL ALL=(ALL) NOPASSWD: ALL/ALL ALL=(ALL) ALL/" /etc/sudoers
+  chmod 0440 /etc/sudoers
+fi
 
 # bug 544314, we need to use pam-config to correctly reset the gnome-keyring-pam config (see bug 723339)
 pam_config_keyring=`rpm -q --scripts gnome-keyring-pam | grep -v " *#" | grep "pam-config *-a" | head -n 1`
@@ -18,14 +20,27 @@ test -n "$pam_config_keyring" && eval "$pam_config_keyring"
 pam-config -d --nullok
 
 # remove unneeded /license.tar.gz
-rm /license.tar.gz
+rm /license.tar.gz || true
+
+# remove susestudio files
+#rm -rf /studio || true
+#rm /bootincluded_archives.filelist || true
 
 # remove langset stuff
-rm /etc/langset.sh
-rm -rf /etc/langset/
+rm /etc/langset.sh || true
+rm -rf /etc/langset/ || true
 
-# bug 391798
-sed -i -e 's,DISPLAYMANAGER_AUTOLOGIN="linux",DISPLAYMANAGER_AUTOLOGIN="",'  /etc/sysconfig/displaymanager
+# remove default live-cd user, only if there are more users
+live_user="linux"
+if [ `ls /home | grep -c "^"` != "1" ] && [ -e "/home/${live_user}" ] ; then
+  
+  # bug 391798
+  sed -i -e 's,DISPLAYMANAGER_AUTOLOGIN="${live_user}",DISPLAYMANAGER_AUTOLOGIN="",'  /etc/sysconfig/displaymanager
+
+  userdel ${live_user} || true
+  rm -rf "/home/${live_user}" || true
+  
+fi
 
 rm -f /var/lib/zypp/AnonymousUniqueId
 rmdir /livecd || true

--- a/package/yast2-live-installer.changes
+++ b/package/yast2-live-installer.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Mon Jun  5 20:12:52 UTC 2017 - opensuse.lietuviu.kalba@gmail.com
 
+- Requires disk and partitioning tools (boo#1042559, boo#1043270)
 - Use /etc/products.d/openSUSE.prod as /etc/products.d/baseproduct
   (boo#1011147)
 - Requires yast2-qt-branding instead of yast2-qt-branding-openSUSE

--- a/package/yast2-live-installer.changes
+++ b/package/yast2-live-installer.changes
@@ -1,9 +1,18 @@
 -------------------------------------------------------------------
+Mon Jun  5 20:12:52 UTC 2017 - opensuse.lietuviu.kalba@gmail.com
+
+- Use /etc/products.d/openSUSE.prod as /etc/products.d/baseproduct
+  (boo#1011147)
+- Requires yast2-qt-branding instead of yast2-qt-branding-openSUSE
+- 3.1.11
+
+-------------------------------------------------------------------
 Fri Jul 29 09:48:41 UTC 2016 - cyberorg@opensuse.org
 
 - remove mkinitrd workaround from correct_live_for_reboot,
   not needed anymore
-- boo #991084 
+- boo #991084
+- 3.1.10
 
 -------------------------------------------------------------------
 Thu Jul 28 13:03:03 UTC 2016 - cyberorg@opensuse.org
@@ -12,6 +21,7 @@ Thu Jul 28 13:03:03 UTC 2016 - cyberorg@opensuse.org
   these scripts are required to get yast2-live-installer function,
   the scripts belong in this package
 - Added Requires for yast modules needed by live-installer
+- 3.1.9
 
 -------------------------------------------------------------------
 Tue Jun  7 08:21:02 UTC 2016 - igonzalezsosa@suse.com

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -44,8 +44,6 @@ Requires:       yast2-qt-branding
 Requires:       yast2-storage
 Requires:       yast2-users
 Requires:       yast2-ruby-bindings >= 1.0.0
-# openSUSE-release contains /etc/products.d/openSUSE.prod (boo#1011147)
-Requires:       openSUSE-release
 
 %description
 This package contains the YaST component to deploy a live media to the

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -53,6 +53,7 @@ Requires:       jfsutils
 Requires:       hfsutils
 Requires:       kpartx
 Requires:       lvm2
+Requires:       ntfs-3g
 Requires:       ntfsprogs
 Requires:       os-prober
 Requires:       reiserfs

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -45,15 +45,18 @@ Requires:       yast2-storage
 Requires:       yast2-users
 Requires:       yast2-ruby-bindings >= 1.0.0
 # disk and partitioning utils/tools
-Requires:       sg3_utils
 Requires:       btrfsprogs
 Requires:       dosfstools
+Requires:       dmraid
 Requires:       e2fsprogs
 Requires:       jfsutils
 Requires:       hfsutils
+Requires:       kpartx
 Requires:       lvm2
 Requires:       ntfsprogs
+Requires:       os-prober
 Requires:       reiserfs
+Requires:       sg3_utils
 Requires:       xfsprogs
 
 %description

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -65,11 +65,11 @@ cp %{SOURCE2} %{buildroot}/%_bindir/
 chmod 755 %{buildroot}/%_bindir/*
 
 %post
-if [ -f /etc/products.d/baseproduct ] ; then
-   rm /etc/products.d/baseproduct
-fi
-if [ -f /etc/products.d/openSUSE.prod ] ; then
-   ln -s /etc/products.d/openSUSE.prod /etc/products.d/baseproduct
+if ( [ ! -L /etc/products.d/baseproduct ] &&  [ -f /etc/products.d/openSUSE.prod ] ) ; then
+  if [   -f /etc/products.d/baseproduct ] ; then
+    rm /etc/products.d/baseproduct
+  fi
+  ln -s /etc/products.d/openSUSE.prod /etc/products.d/baseproduct
 fi
 %files
 %defattr(-,root,root)

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -51,6 +51,7 @@ Requires:       dosfstools
 Requires:       e2fsprogs
 Requires:       jfsutils
 Requires:       hfsutils
+Requires:       lvm2
 Requires:       ntfsprogs
 Requires:       reiserfs
 Requires:       xfsprogs

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-live-installer
 #
-# Copyright (c) 2013 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,33 +17,35 @@
 
 
 Name:           yast2-live-installer
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
-
+Summary:        YaST2 - Installation from Live Media
+Group:          System/YaST
+License:        GPL-2.0+
+BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
 Source1:        correct_live_for_reboot
 Source2:        correct_live_install
-Group:	        System/YaST
-License:        GPL-2.0+
-
-# Internet and InternetDevices
-Requires:	yast2 >= 2.16.6
-Requires:	yast2-network >= 2.16.6
-Requires:	yast2-bootloader >= 2.18.7
-#unified progress
-Requires:	yast2-installation >= 2.18.17
-Requires:       yast2-qt-branding-openSUSE
-Requires:       yast2-users
-Requires:	yast2-bootloader yast2-country yast2-storage
-BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-testsuite
+BuildRequires:  perl-XML-Writer
+BuildRequires:  update-desktop-files
+BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 3.1.10
-
-BuildArchitectures:	noarch
-
+BuildRequires:  yast2-testsuite
+# Internet and InternetDevices
+Requires:       yast2 >= 2.16.6
+Requires:       yast2-bootloader >= 2.18.7
+Requires:       yast2-network >= 2.16.6
+# unified progress
+Requires:       yast2-bootloader
+Requires:       yast2-country
+Requires:       yast2-installation >= 2.18.17
+Requires:       yast2-qt-branding
+Requires:       yast2-storage
+Requires:       yast2-users
 Requires:       yast2-ruby-bindings >= 1.0.0
-
-Summary:	YaST2 - Installation from Live Media
+# openSUSE-release contains /etc/products.d/openSUSE.prod (boo#1011147)
+Requires:       openSUSE-release
 
 %description
 This package contains the YaST component to deploy a live media to the
@@ -62,6 +64,13 @@ cp %{SOURCE1} %{buildroot}/%_bindir/
 cp %{SOURCE2} %{buildroot}/%_bindir/
 chmod 755 %{buildroot}/%_bindir/*
 
+%post
+if [ -f /etc/products.d/baseproduct ] ; then
+   rm /etc/products.d/baseproduct
+fi
+if [ -f /etc/products.d/openSUSE.prod ] ; then
+   ln -s /etc/products.d/openSUSE.prod /etc/products.d/baseproduct
+fi
 %files
 %defattr(-,root,root)
 %{yast_clientdir}/*.rb
@@ -70,3 +79,5 @@ chmod 755 %{buildroot}/%_bindir/*
 %_bindir/correct_live_for_reboot
 %_bindir/correct_live_install
 %doc %{yast_docdir}
+
+%changelog

--- a/package/yast2-live-installer.spec
+++ b/package/yast2-live-installer.spec
@@ -44,6 +44,16 @@ Requires:       yast2-qt-branding
 Requires:       yast2-storage
 Requires:       yast2-users
 Requires:       yast2-ruby-bindings >= 1.0.0
+# disk and partitioning utils/tools
+Requires:       sg3_utils
+Requires:       btrfsprogs
+Requires:       dosfstools
+Requires:       e2fsprogs
+Requires:       jfsutils
+Requires:       hfsutils
+Requires:       ntfsprogs
+Requires:       reiserfs
+Requires:       xfsprogs
 
 %description
 This package contains the YaST component to deploy a live media to the


### PR DESCRIPTION
  (boo#1011147)
- Requires yast2-qt-branding instead of yast2-qt-branding-openSUSE
- 3.1.11